### PR TITLE
GitHub Actions set-output updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Set variables
         id: set-variables
         run: |
-          echo "::set-output name=cache-key::${{ env.cache_key }}"
           echo "cache-key=${{ env.cache_key }}" >> "$GITHUB_OUTPUT"
           echo "::set-output name=extensions::${{ env.extensions }}"
           echo "::set-output name=tools::${{ env.tools }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
         id: set-variables
         run: |
           echo "::set-output name=cache-key::${{ env.cache_key }}"
+          echo "cache-key=${{ env.cache_key }}" >> "$GITHUB_OUTPUT"
           echo "::set-output name=extensions::${{ env.extensions }}"
           echo "::set-output name=tools::${{ env.tools }}"
           echo "::set-output name=php_versions::['8.1', '8.2']"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,10 @@ jobs:
         id: set-variables
         run: |
           echo "cache-key=${{ env.cache_key }}" >> "$GITHUB_OUTPUT"
-          echo "::set-output name=extensions::${{ env.extensions }}"
-          echo "::set-output name=tools::${{ env.tools }}"
-          echo "::set-output name=php_versions::['8.1', '8.2']"
-          echo "::set-output name=php_version::['8.1']"
+          echo "extensions=${{ env.extensions }}" >> "$GITHUB_OUTPUT"
+          echo "tools=${{ env.tools }}" >> "$GITHUB_OUTPUT"
+          echo "php_versions=${{ ['8.1', '8.2'] }}" >> "$GITHUB_OUTPUT"
+          echo "php_version=${{ ['8.1'] }}" >> "$GITHUB_OUTPUT"
 
   code-style:
     needs: [ env-setup ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
           echo "cache-key=${{ env.cache_key }}" >> "$GITHUB_OUTPUT"
           echo "extensions=${{ env.extensions }}" >> "$GITHUB_OUTPUT"
           echo "tools=${{ env.tools }}" >> "$GITHUB_OUTPUT"
-          echo "php_versions=${{ ['8.1', '8.2'] }}" >> "$GITHUB_OUTPUT"
-          echo "php_version=${{ ['8.1'] }}" >> "$GITHUB_OUTPUT"
+          echo "php_versions=['8.1', '8.2']" >> "$GITHUB_OUTPUT"
+          echo "php_version=['8.1']" >> "$GITHUB_OUTPUT"
 
   code-style:
     needs: [ env-setup ]


### PR DESCRIPTION
[Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).